### PR TITLE
Provide tag as shortcut for forms in templates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "CSRF", targets: ["CSRF"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "3.1.0")
     ],
     targets: [
         .target(name: "CSRF", dependencies: ["Vapor"], path: "./Sources"),

--- a/README.md
+++ b/README.md
@@ -100,3 +100,31 @@ router.get("test-no-session") { request in
     return response
 }
 ```
+
+## Usage with Leaf and forms
+
+To use this package in combination with Leaf to protect forms, there is a tag provided for convenience:
+
+* Add `CSRFFormFieldTag` in `configure.swift`
+
+```swift
+var tags = LeafTagConfig.default()
+// [...]
+tags.use(CSRFFormFieldTag.self, as "csrfFormField")
+services.register(tags)
+```
+
+* Use `CSRFFormFieldTag` in Leaf templates, e.g. like this
+
+```html
+<form method="post">
+
+<input type="text" name="username">
+<input type="text" name="password">
+[...]
+
+#csrfFormField()
+
+<input type="submit" value="Login">
+</form>
+```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To use this package in combination with Leaf to protect forms, there is a tag pr
 ```swift
 services.register { container -> LeafTagConfig in
 	var config = LeafTagConfig.default()
-	// [...]
+	// ...
 	config.use(CSRFFormFieldTag(), as: "csrfFormField")
 	return config
 }

--- a/README.md
+++ b/README.md
@@ -108,10 +108,12 @@ To use this package in combination with Leaf to protect forms, there is a tag pr
 * Add `CSRFFormFieldTag` in `configure.swift`
 
 ```swift
-var tags = LeafTagConfig.default()
-// [...]
-tags.use(CSRFFormFieldTag.self, as "csrfFormField")
-services.register(tags)
+services.register { container -> LeafTagConfig in
+	var config = LeafTagConfig.default()
+	// [...]
+	config.use(CSRFFormFieldTag(), as: "csrfFormField")
+	return config
+}
 ```
 
 * Use `CSRFFormFieldTag` in Leaf templates, e.g. like this
@@ -121,7 +123,7 @@ services.register(tags)
 
 <input type="text" name="username">
 <input type="text" name="password">
-[...]
+[…]
 
 #csrfFormField()
 

--- a/Sources/CSRF.swift
+++ b/Sources/CSRF.swift
@@ -18,6 +18,13 @@ public struct CSRF: Middleware, Service {
         self.tokenRetrieval = tokenRetrieval ?? CSRF.defaultTokenRetrieval
     }
     
+    /// Provide CSRFFormFieldTag
+    public func register(_ services: inout Services) throws {
+        services.register { container in
+            return CSRFFormFieldTag()
+        }
+    }
+
     public func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
         let method = request.http.method
         

--- a/Sources/CSRF.swift
+++ b/Sources/CSRF.swift
@@ -18,13 +18,6 @@ public struct CSRF: Middleware, Service {
         self.tokenRetrieval = tokenRetrieval ?? CSRF.defaultTokenRetrieval
     }
     
-    /// Provide CSRFFormFieldTag
-    public func register(_ services: inout Services) throws {
-        services.register { container in
-            return CSRFFormFieldTag()
-        }
-    }
-
     public func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
         let method = request.http.method
         

--- a/Sources/CSRFFormFieldTag.swift
+++ b/Sources/CSRFFormFieldTag.swift
@@ -1,0 +1,20 @@
+import Vapor
+
+public final class CSRFFormFieldTag: TagRenderer {
+    public init() {}
+
+    public func render(tag: TagContext) throws -> EventLoopFuture<TemplateData> {
+        try tag.requireNoBody()
+        try tag.requireParameterCount(0)
+        guard let request = tag.container as? Request else {
+            throw Abort(.internalServerError, reason: "Container of Tag is not of type Request")
+        }
+
+        let csrfToken = try tag.container.make(CSRF.self).createToken(from: request)
+        let formFieldHtml = "<input type='hidden' name='_csrf' value='\(csrfToken)'>"
+
+        return Future.map(on: tag) {
+            .string(formFieldHtml)
+        }
+    }
+}


### PR DESCRIPTION
Since preventing CSRF is quite useful for html forms on web pages, I added a template tag. When using html forms, you can use this tag to insert a hidden input field for `_csrf`, which is after submitting automatically checked by this middleware.

My changes provide the tag, but didn't introduce a dependency on Leaf, because it only uses parts of `TemplateKit`, which is already part of the `Vapor` package. So when programming APIs, this is only one unnecessary file (and not an unused dependency), but when programming web pages, this can be quite helpful.